### PR TITLE
Fixed indentation and the DTD

### DIFF
--- a/src/Text/XML/Plist/Write.hs
+++ b/src/Text/XML/Plist/Write.hs
@@ -28,11 +28,9 @@ import Control.Monad (void)
 import Control.Arrow.IOStateListArrow
 import Text.XML.HXT.Arrow.WriteDocument
 import Text.XML.HXT.Arrow.XmlArrow
-import Text.XML.HXT.Arrow.XmlOptions
 import Control.Arrow
 import Control.Arrow.ArrowList
 import Text.XML.HXT.DOM.TypeDefs
-import Text.XML.HXT.Arrow.XmlState.TypeDefs
 
 -- | Write 'PlObject' to file
 writePlistToFile :: String -> PlObject -> IO ()


### PR DESCRIPTION
I am new to Haskell, so I am not sure if I did this correctly. I was using your library and was having problems with the indentation and the DTD. When I would run

```
> import Text.XML.Plist
> writePlistToFile "test.plist" (PlDict [("Label", (PlString "test")), ("ProgramArguments", (PlString "test"))])
```

inside of `ghci`, the result file would look like

```
<?xml version="1.0" encoding="UTF-8"?>
<plist version="1.0"><dict><key>Label</key><string>test</string><key>ProgramArguments</key><string>test</string></dict></plist>
```

I looked through the code and found that you were setting both the indentation and DTD, but it was being ignored. I looked at the HXT documentation and found that the way these values are set has changed (must be a newer version?). I updated the code and I get the correct result now.

I also removed some imports because when I was compiling the code, ghc was complaining that they were redundant imports.
