### PR TITLE
Update to use MonadFail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 dist/
+dist-newstyle/

--- a/plist.cabal
+++ b/plist.cabal
@@ -27,7 +27,7 @@ source-repository head
 
 library
   hs-source-dirs:        src
-  build-depends:         base >= 4.3 && < 5,
+  build-depends:         base >= 4.9 && < 5,
                          base64-bytestring >= 1.0,
                          bytestring >= 0.10,
                          hxt >= 9 && < 10

--- a/src/Text/XML/Plist/PlObject.hs
+++ b/src/Text/XML/Plist/PlObject.hs
@@ -38,27 +38,26 @@ data PlObject
   | PlDate String -- ^ date (ISO 8601, but currently it is not validated)
   deriving (Eq, Ord, Show, Read)
 
-fromPlString :: Monad m => PlObject -> m String
+fromPlString :: MonadFail m => PlObject -> m String
 fromPlString (PlString str) = return str
 fromPlString o = fail $ "not a string: " ++ show o
 
-fromPlBool :: Monad m => PlObject -> m Bool
+fromPlBool :: MonadFail m => PlObject -> m Bool
 fromPlBool (PlBool bool) = return bool
 fromPlBool o = fail $ "not a bool: " ++ show o
 
-fromPlInteger :: Monad m => PlObject -> m Int
+fromPlInteger :: MonadFail m => PlObject -> m Int
 fromPlInteger (PlInteger i) = return i
 fromPlInteger o = fail $ "not an integer: " ++ show o
 
-fromPlReal :: Monad m => PlObject -> m Double
+fromPlReal :: MonadFail m => PlObject -> m Double
 fromPlReal (PlReal r) = return r
 fromPlReal o = fail $ "not a real: " ++ show o
 
-fromPlArray :: Monad m => PlObject -> m [PlObject]
+fromPlArray :: MonadFail m => PlObject -> m [PlObject]
 fromPlArray (PlArray arr) = return arr
 fromPlArray o = fail $ "not an array: " ++ show o
 
-fromPlDict :: Monad m => PlObject -> m [(String, PlObject)]
+fromPlDict :: MonadFail m => PlObject -> m [(String, PlObject)]
 fromPlDict (PlDict d) = return d
 fromPlDict o = fail $ "not a dictionary: " ++ show o
-

--- a/src/Text/XML/Plist/Read.hs
+++ b/src/Text/XML/Plist/Read.hs
@@ -69,14 +69,14 @@ xmlToObject = choiceA
   , hasName "dict" :-> (readDict >>> arr PlDict)
   , hasName "data" :-> (
     innerText >>>
-    arr (decode' . foldr (++) "" . lines) >>>
+    arr (decode' . concat . lines) >>>
     isA isJust >>>
     arr fromJust >>>
     arr PlData
     )
   , hasName "date" :-> (innerText >>> arr PlDate) ]
   where
-    decode' = either (const Nothing) Just . fmap unpack . decode . pack
+    decode' = either (const Nothing) (Just . unpack) . decode . pack
 
 readDict :: ArrowXml a => a XmlTree [(String, PlObject)]
 readDict = listA $ readDict' $< listA (getChildren >>> isElem)

--- a/src/Text/XML/Plist/Write.hs
+++ b/src/Text/XML/Plist/Write.hs
@@ -23,14 +23,14 @@ objectToXml
 
 import Text.XML.Plist.PlObject
 import Text.XML.HXT.Arrow.XmlState
-import Control.Monad (void, liftM)
+import Control.Monad (void)
 import Control.Arrow.IOStateListArrow
 import Text.XML.HXT.Arrow.WriteDocument
 import Text.XML.HXT.Arrow.XmlArrow
 import Control.Arrow
 import Control.Arrow.ArrowList
 import Text.XML.HXT.DOM.TypeDefs
-import Data.ByteString.Base64 (encode, joinWith)
+import Data.ByteString.Base64 (encode)
 import Data.ByteString (pack)
 import Data.ByteString.Char8 (unpack)
 
@@ -45,7 +45,7 @@ writePlist fileName = objectToPlist >>>
 
 -- | Write 'PlObject' to String
 writePlistToString :: PlObject -> IO String
-writePlistToString object = liftM concat $ runX (constA object >>> writePlist')
+writePlistToString object = concat <$> runX (constA object >>> writePlist')
 
 writePlist' :: IOSLA (XIOState s) PlObject String
 writePlist' = objectToPlist >>>
@@ -71,5 +71,5 @@ objectToXml (PlDict objects) = selem "dict" elems where
   elems = concatMap toXml objects
   toXml (key, val) = [selem "key" [txt key], objectToXml val]
 objectToXml (PlData dat) = selem "data" [txt $ enc dat] where
-  enc = unpack . joinWith "\n" 20 . encode . pack
+  enc = unpack . encode . pack
 objectToXml (PlDate date) = selem "date" [txt date]


### PR DESCRIPTION
This PR updates the package to work with versions of GHC (8.8 and higher) where `fail` has been removed from `Monad`.